### PR TITLE
Allow passing a PR number

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@ This action will create, deploy, and destroy Fly apps. Just set an Action Secret
 
 If you have an existing `fly.toml` in your repo, this action will copy it with a new name when deploying. By default, Fly apps will be named with the scheme `pr-{number}-{repo_org}-{repo_name}`.
 
+This Action is a fork from https://github.com/superfly/fly-pr-review-apps to accomodate Fewlines' needs. Please use the official action if you can.
+
 ## Inputs
 
-| name       | description                                                                                                                                                                                              |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`     | The name of the Fly app. Alternatively, set the env `FLY_APP`. For safety, must include the PR number. Example: `myapp-pr-${{ github.event.number }}`. Defaults to `pr-{number}-{repo_org}-{repo_name}`. |
-| `region`   | Which Fly region to run the app in. Alternatively, set the env `FLY_REGION`. Defaults to `iad`.                                                                                                          |
-| `org`      | Which Fly organization to launch the app under. Alternatively, set the env `FLY_ORG`. Defaults to `personal`.                                                                                            |
-| `path`     | Path to run the `flyctl` commands from. Useful if you have an existing `fly.toml` in a subdirectory.                                                                                                     |
-| `postgres` | Optional name of an existing Postgres cluster to `flyctl postgres attach` to.                                                                                                                            |
-| `update`   | Whether or not to update this Fly app when the PR is updated. Default `true`.                                                                                                                            |
+| name        | description                                                                                                                                                                                              |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | The name of the Fly app. Alternatively, set the env `FLY_APP`. For safety, must include the PR number. Example: `myapp-pr-${{ github.event.number }}`. Defaults to `pr-{number}-{repo_org}-{repo_name}`. |
+| `region`    | Which Fly region to run the app in. Alternatively, set the env `FLY_REGION`. Defaults to `iad`.                                                                                                          |
+| `org`       | Which Fly organization to launch the app under. Alternatively, set the env `FLY_ORG`. Defaults to `personal`.                                                                                            |
+| `path`      | Path to run the `flyctl` commands from. Useful if you have an existing `fly.toml` in a subdirectory.                                                                                                     |
+| `postgres`  | Optional set to true to add a Postgres cluster to your review app.                                                                                                                            |
+| `pr_number` | Optional set the number of the PR (this is useful in the case of a GitHub Action using `workflow_dispatch` for instance).                                                                                                                                                                       |
+| `update`    | Whether or not to update this Fly app when the PR is updated. Default `true`.                                                                                                                            |
 
 ## Required Secrets
 
@@ -107,7 +110,7 @@ steps:
     id: deploy
     uses: fewlinesco/fly-staging-app@v1
     with:
-      postgres: myapp-postgres-staging-apps
+      postgres: true
 ```
 
 ## Example with multiple Fly apps

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,8 @@ inputs:
     description: path to a directory containing a fly.toml to clone
   postgres:
     description: Optionally attach the app to a pre-existing Postgres cluster on Fly
+  pr_number:
+    description: Optionnally explicitly set the PR number to use
   update:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,9 +7,9 @@ if [ -n "$INPUT_PATH" ]; then
   cd "$INPUT_PATH" || exit
 fi
 
-PR_NUMBER=$(jq -r .number /github/workflow/event.json)
-if [ -z "$PR_NUMBER" ]; then
-  echo "This action only supports pull_request actions."
+PR_NUMBER=${INPUT_PR_NUMBER:-$(jq -r .number /github/workflow/event.json)}
+if [ "$PR_NUMBER" = "null" ]; then
+  echo "This action requires a PR number to be passed in as an input or be run from a pull request."
   exit 1
 fi
 


### PR DESCRIPTION
This PR adds a way to pass a PR number to the action.

This should be useful when we want to use this action inside a workflow that is triggerred by a CURL call.
Because a worfklow triggerred via a CURL call won't trigger any event, we sometimes need to deploy inside of it.