### PR TITLE
Add a new input option: event_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ This Action is a fork from https://github.com/superfly/fly-pr-review-apps to acc
 
 ## Inputs
 
-| name        | description                                                                                                                                                                                              |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`      | The name of the Fly app. Alternatively, set the env `FLY_APP`. For safety, must include the PR number. Example: `myapp-pr-${{ github.event.number }}`. Defaults to `pr-{number}-{repo_org}-{repo_name}`. |
-| `region`    | Which Fly region to run the app in. Alternatively, set the env `FLY_REGION`. Defaults to `iad`.                                                                                                          |
-| `org`       | Which Fly organization to launch the app under. Alternatively, set the env `FLY_ORG`. Defaults to `personal`.                                                                                            |
-| `path`      | Path to run the `flyctl` commands from. Useful if you have an existing `fly.toml` in a subdirectory.                                                                                                     |
-| `postgres`  | Optional set to true to add a Postgres cluster to your review app.                                                                                                                            |
-| `pr_number` | Optional set the number of the PR (this is useful in the case of a GitHub Action using `workflow_dispatch` for instance).                                                                                                                                                                       |
-| `update`    | Whether or not to update this Fly app when the PR is updated. Default `true`.                                                                                                                            |
+| name         | description                                                                                                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`       | The name of the Fly app. Alternatively, set the env `FLY_APP`. For safety, must include the PR number. Example: `myapp-pr-${{ github.event.number }}`. Defaults to `pr-{number}-{repo_org}-{repo_name}`. |
+| `region`     | Which Fly region to run the app in. Alternatively, set the env `FLY_REGION`. Defaults to `iad`.                                                                                                          |
+| `org`        | Which Fly organization to launch the app under. Alternatively, set the env `FLY_ORG`. Defaults to `personal`.                                                                                            |
+| `path`       | Path to run the `flyctl` commands from. Useful if you have an existing `fly.toml` in a subdirectory.                                                                                                     |
+| `postgres`   | Optional set to true to add a Postgres cluster to your review app.                                                                                                                                       |
+| `pr_number`  | Optional set the number of the PR (this is useful in the case of a GitHub Action using `workflow_dispatch` for instance).                                                                                |
+| `event_type` | Optional set the event_type of the PR (this is useful in the case of a GitHub Action using `workflow_dispatch` to specify a closed event for instance).                                                  |
+| `update`     | Whether or not to update this Fly app when the PR is updated. Default `true`.                                                                                                                            |
 
 ## Required Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,8 @@ inputs:
     description: Optionally attach the app to a pre-existing Postgres cluster on Fly
   pr_number:
     description: Optionnally explicitly set the PR number to use
+  event_type:
+    description: Optionnaly explicitly set the event type to use
   update:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 
 REPO_OWNER=$(jq -r .organization.login /github/workflow/event.json)
 REPO_NAME=$(jq -r .repository.name /github/workflow/event.json)
-EVENT_TYPE=$(jq -r .action /github/workflow/event.json)
+EVENT_TYPE=${INPUT_EVENT_TYPE:-$(jq -r .action /github/workflow/event.json)}
 
 # Default the Fly app name to pr-{number}-{repo_owner}-{repo_name}
 app="${INPUT_NAME:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME}"


### PR DESCRIPTION
This PR adds the option to explicitly pass the `event_type` and especially the `closed` event when a PR is closed with a `workflow_dispatch`.