### PR TITLE
Fix region not being set at app creation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,6 @@ inputs:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true
   secrets:
-    description: "Secrets to pass to the app, separated by semicolons (eg: \"SECRET1;SECRET2\")"
+    description: 'Secrets to pass to the app, separated by semicolons (eg: "SECRET1;SECRET2")'
   postgres_vm_size:
-    description: "Size of the Postgres VM to create (default: \"shared-cpu-1x\")"
+    description: 'Size of the Postgres VM to create (default: "shared-cpu-1x")'


### PR DESCRIPTION
Fix the region not being set when creating the application for the first time on Fly.

This cause the app to sometimes be assigned to a far away region which impacts negatively performance.

Also, inverse the order of secrets and first deploy because there's currently a bug with Fly where secrets set before any deployment are ignored.