### PR TITLE
Make fly io review apps idempotent on pg trb 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
 
       - name: Deploy
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v2.3
+        uses: fewlinesco/fly-io-review-apps@v2.4
 ```
 
 ## Cleaning up GitHub environments
@@ -86,7 +86,7 @@ jobs:
 
       - name: Deploy app
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v2.3
+        uses: fewlinesco/fly-io-review-apps@v2.4
 
       - name: Clean up GitHub environment
         uses: strumwolf/delete-deployment-environment@v2
@@ -111,7 +111,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v2.3
+    uses: fewlinesco/fly-io-review-apps@v2.4
     with:
       postgres: true
 ```
@@ -125,7 +125,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v2.3
+    uses: fewlinesco/fly-io-review-apps@v2.4
     with:
       postgres: true
       region: cdg
@@ -146,7 +146,7 @@ steps:
   - uses: actions/checkout@v3
 
   - name: Deploy redis
-    uses: fewlinesco/fly-io-review-apps@v2.3
+    uses: fewlinesco/fly-io-review-apps@v2.4
     with:
       update: false # Don't need to re-deploy redis when the PR is updated
       path: redis # Keep fly.toml in a subdirectory to avoid confusing flyctl
@@ -155,7 +155,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/ffly-io-review-apps@v2.3
+    uses: fewlinesco/ffly-io-review-apps@v2.4
     with:
       name: pr-${{ github.event.number }}-myapp-app
 ```


### PR DESCRIPTION
This PR does three different things and it's a bit hard to see in the movement of the code.

First, the cluster creation will only be done once just after the database creation and since it's now under the "if db not exists", it will only run when it does not exists.

Second, I removed the `|| true` of the DB creation: if it does not create the DB when we want it to be, it should be a fail.

Third, I moved the `flyctl attach` command to be run everytime. This is because shit happens in Fly and sometimes the DB is not attached properly and just running it again could fix it.