### PR TITLE
Switch deployment strategy from immediate to rolling

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,10 +61,8 @@ if [ -n "$INPUT_POSTGRES" ]; then
   flyctl postgres attach --app "$app" "$postgres_app" || true
 fi
 
-
-
 if [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy immediate
+  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy rolling
 fi
 
 if [ -n "$INPUT_SECRETS" ]; then


### PR DESCRIPTION
By switching the strategy to rolling, the `flyctl deploy [...]` command waits for healthcheck to pass.

This should help in having the action marked as failed if the deployment fails.