### PR TITLE
Strategy immediate and avoid copy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
 
       - name: Deploy
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v2.4
+        uses: fewlinesco/fly-io-review-apps@v2.6
 ```
 
 ## Cleaning up GitHub environments
@@ -86,7 +86,7 @@ jobs:
 
       - name: Deploy app
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v2.4
+        uses: fewlinesco/fly-io-review-apps@v2.6
 
       - name: Clean up GitHub environment
         uses: strumwolf/delete-deployment-environment@v2
@@ -111,7 +111,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v2.4
+    uses: fewlinesco/fly-io-review-apps@v2.6
     with:
       postgres: true
 ```
@@ -125,7 +125,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v2.4
+    uses: fewlinesco/fly-io-review-apps@v2.6
     with:
       postgres: true
       region: cdg
@@ -146,7 +146,7 @@ steps:
   - uses: actions/checkout@v3
 
   - name: Deploy redis
-    uses: fewlinesco/fly-io-review-apps@v2.4
+    uses: fewlinesco/fly-io-review-apps@v2.6
     with:
       update: false # Don't need to re-deploy redis when the PR is updated
       path: redis # Keep fly.toml in a subdirectory to avoid confusing flyctl
@@ -155,7 +155,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/ffly-io-review-apps@v2.4
+    uses: fewlinesco/ffly-io-review-apps@v2.6
     with:
       name: pr-${{ github.event.number }}-myapp-app
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ fi
 
 # Create (using launch as create doesn't accept --region) the Fly app.
 if ! flyctl status --app "$app"; then
-  flyctl launch --copy-config --name "$app" --org "$org" --image "$image" --region "$region" --no-deploy
+  flyctl launch --name "$app" --org "$org" --image "$image" --region "$region" --no-deploy
 fi
 
 # Attach postgres cluster to the app if specified.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,7 @@ if [ -n "$INPUT_POSTGRES" ]; then
 fi
 
 if [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy rolling
+  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy immediate
 fi
 
 if [ -n "$INPUT_SECRETS" ]; then


### PR DESCRIPTION
This PR changes two things in our deploy method:
- set the strategy to "immediate"
- removes the `--copy-config`

Firstly, the change to `--strategy immediate` is because of a Fly bug.
Ideally, we would set secrets before the first deploy and we could use the rolling strategy. But since we sometimes have secrets not set when we set them before the first deploy, we need to set them after.
Therefore, we have a first deploy without all needed secrets and errors when we try to start the instances.

If we're in rolling strategy, this will stop the deployment and secrets won't be set.
So for now, we need to keep the immediate strategy.

Secondly, removing the `--copy-config` will avoid having Fly creates a `fly.toml` with an app name and trigger interactive prompts because the app name is not the same for the postgres app.