### PR TITLE
Use a real copy of the config for the DB

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,10 +56,7 @@ if [ -n "$INPUT_POSTGRES" ]; then
       cluster_scale=$(echo "$region $region $INPUT_POSTGRES_CLUSTER_REGIONS" | awk '{print NF}')
 
       cp fly.toml fly-postgres.toml
-      ls
-      cat fly-postgres.toml
       sed -i "s/app = \"$app\"/app = \"$postgres_app\"/" fly-postgres.toml
-      cat fly-postgres.toml
 
       flyctl scale count "$cluster_scale" --app "$postgres_app" --config fly-postgres.toml
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,10 @@ if [ -n "$INPUT_POSTGRES" ]; then
       cluster_scale=$(echo "$region $region $INPUT_POSTGRES_CLUSTER_REGIONS" | awk '{print NF}')
 
       cp fly.toml fly-postgres.toml
-      sed -i '' "s/app = \"$app\"/app = \"$postgres_app\"/" fly-postgres.toml
+      ls
+      cat fly-postgres.toml
+      sed -i "s/app = \"$app\"/app = \"$postgres_app\"/" fly-postgres.toml
+      cat fly-postgres.toml
 
       flyctl scale count "$cluster_scale" --app "$postgres_app" --config fly-postgres.toml
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ fi
 
 # Create (using launch as create doesn't accept --region) the Fly app.
 if ! flyctl status --app "$app"; then
-  flyctl launch --name "$app" --org "$org" --image "$image" --region "$region" --no-deploy
+  flyctl launch --copy-config --name "$app" --org "$org" --image "$image" --region "$region" --no-deploy
 fi
 
 # Attach postgres cluster to the app if specified.
@@ -55,7 +55,10 @@ if [ -n "$INPUT_POSTGRES" ]; then
       done
       cluster_scale=$(echo "$region $region $INPUT_POSTGRES_CLUSTER_REGIONS" | awk '{print NF}')
 
-      flyctl scale count "$cluster_scale" --app "$postgres_app"
+      cp fly.toml fly-postgres.toml
+      sed -i '' "s/app = \"$app\"/app = \"$postgres_app\"/" fly-postgres.toml
+
+      flyctl scale count "$cluster_scale" --app "$postgres_app" --config fly-postgres.toml
     fi
   fi
   flyctl postgres attach --app "$app" "$postgres_app" || true


### PR DESCRIPTION
Apparently it can't work without `--copy-config` because the `flyctl launch` command **needs** to have a value for `app` in the `fly.toml` if we want to avoid the interactive prompt asking if we're sure.

However, on the contrary, `flyctl scale` will not accept `--app` without asking if the name is different in the fly.toml. 

So... I made a copy of `fly.toml`, change the name to fit the posgres app and use it instead.
I've tested this on Turbo by using this branch name as a version of the action 👍 