### PR TITLE
change deprecated "set-output" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jobs:
 
       - name: Deploy app
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v2.7
+        uses: fewlinesco/fly-io-review-apps@v2.8
 
       - name: Clean up GitHub environment
         uses: strumwolf/delete-deployment-environment@v2
@@ -111,7 +111,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v2.7
+    uses: fewlinesco/fly-io-review-apps@v2.8
     with:
       postgres: true
 ```
@@ -125,7 +125,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v2.7
+    uses: fewlinesco/fly-io-review-apps@v2.8
     with:
       postgres: true
       region: cdg
@@ -146,7 +146,7 @@ steps:
   - uses: actions/checkout@v3
 
   - name: Deploy redis
-    uses: fewlinesco/fly-io-review-apps@v2.7
+    uses: fewlinesco/fly-io-review-apps@v2.8
     with:
       update: false # Don't need to re-deploy redis when the PR is updated
       path: redis # Keep fly.toml in a subdirectory to avoid confusing flyctl
@@ -155,7 +155,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/ffly-io-review-apps@v2.7
+    uses: fewlinesco/ffly-io-review-apps@v2.8
     with:
       name: pr-${{ github.event.number }}-myapp-app
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
 
       - name: Deploy
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v2.7
+        uses: fewlinesco/fly-io-review-apps@v2.8
 ```
 
 ## Cleaning up GitHub environments

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,6 +77,7 @@ fi
 flyctl status --app "$app" --json >status.json
 hostname=$(jq -r .Hostname status.json)
 appid=$(jq -r .ID status.json)
-echo "::set-output name=hostname::$hostname"
-echo "::set-output name=url::https://$hostname"
-echo "::set-output name=id::$appid"
+
+echo "hostname=$hostname" >> $GITHUB_OUTPUT
+echo "url=https://$hostname" >> $GITHUB_OUTPUT
+echo "id=$appid" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Atm we're using the `set-ouput` command to ouput data from a GH workflow's step to another.

It is now deprecated and is replaced in this PR with the new "environment files" feature: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files.