### PR TITLE
Bluegreen deployment strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
 
       - name: Deploy
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v2.8
+        uses: fewlinesco/fly-io-review-apps@v3.0
 ```
 
 ## Cleaning up GitHub environments
@@ -86,7 +86,7 @@ jobs:
 
       - name: Deploy app
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v2.8
+        uses: fewlinesco/fly-io-review-apps@v3.0
 
       - name: Clean up GitHub environment
         uses: strumwolf/delete-deployment-environment@v2
@@ -111,7 +111,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v2.8
+    uses: fewlinesco/fly-io-review-apps@v3.0
     with:
       postgres: true
 ```
@@ -125,7 +125,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v2.8
+    uses: fewlinesco/fly-io-review-apps@v3.0
     with:
       postgres: true
       region: cdg
@@ -146,7 +146,7 @@ steps:
   - uses: actions/checkout@v3
 
   - name: Deploy redis
-    uses: fewlinesco/fly-io-review-apps@v2.8
+    uses: fewlinesco/fly-io-review-apps@v3.0
     with:
       update: false # Don't need to re-deploy redis when the PR is updated
       path: redis # Keep fly.toml in a subdirectory to avoid confusing flyctl
@@ -155,7 +155,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/ffly-io-review-apps@v2.8
+    uses: fewlinesco/ffly-io-review-apps@v3.0
     with:
       name: pr-${{ github.event.number }}-myapp-app
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ EVENT_TYPE=${INPUT_EVENT_TYPE:-$(jq -r .action /github/workflow/event.json)}
 # Default the Fly app name to pr-{number}-{repo_owner}-{repo_name}
 app="${INPUT_NAME:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME}"
 postgres_app="${INPUT_POSTGRES_NAME:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME-postgres}"
-region="${INPUT_REGION:-${FLY_REGION:-cdg}}"
+region="${INPUT_REGION:-${FLY_REGION:-lhr}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"
 postgres_vm_size="${INPUT_POSTGRES_VM_SIZE:-shared-cpu-1x}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,8 +43,6 @@ fi
 if ! flyctl status --app "$app"; then
   flyctl launch --force-machines --copy-config --name "$app" --org "$org" --image "$image" --region "$region" --no-deploy
   flyctl scale count 2 --app "$app"
-  flyctl ips allocate-v4 --app "$app" --region "$region" --shared
-  flyctl ips allocate-v6 --app "$app"
 
   # if PostgreSQL is requested, create a PostgreSQL App then Deploy Application
   if [ -n "$INPUT_POSTGRES" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,8 @@ fi
 if ! flyctl status --app "$app"; then
   flyctl launch --force-machines --copy-config --name "$app" --org "$org" --image "$image" --region "$region" --no-deploy
   flyctl scale count 2 --app "$app"
+  flyctl ips allocate-v4 --app "$app" --region "$region" --shared
+  flyctl ips allocate-v6 --app "$app"
 
   # if PostgreSQL is requested, create a PostgreSQL App then Deploy Application
   if [ -n "$INPUT_POSTGRES" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,7 @@ if ! flyctl status --app "$app"; then
   flyctl launch --force-machines --copy-config --name "$app" --org "$org" --image "$image" --region "$region" --no-deploy
   flyctl scale count 2 --app "$app"
   flyctl ips allocate-v4 --app "$app" --region "$region" --shared
-  flyctl ips allocate-v6 --app "$app" --region "$region"
+  flyctl ips allocate-v6 --app "$app"
 
   # if PostgreSQL is requested, create a PostgreSQL App then Deploy Application
   if [ -n "$INPUT_POSTGRES" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ EVENT_TYPE=${INPUT_EVENT_TYPE:-$(jq -r .action /github/workflow/event.json)}
 # Default the Fly app name to pr-{number}-{repo_owner}-{repo_name}
 app="${INPUT_NAME:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME}"
 postgres_app="${INPUT_POSTGRES_NAME:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME-postgres}"
-region="${INPUT_REGION:-${FLY_REGION:-lhr}}"
+region="${INPUT_REGION:-${FLY_REGION:-cdg}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"
 postgres_vm_size="${INPUT_POSTGRES_VM_SIZE:-shared-cpu-1x}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ if ! flyctl status --app "$app"; then
       # Fix until Prisma can deal with IPv6 or Fly gives us something else
       connection_string=$(echo $db_output | sed -e 's/[[:space:]]*Connection string:[[:space:]]*//g')
       new_connection_string=$(echo $connection_string | sed -e "s/\.flycast/.internal/g")
-      bash -c "flyctl deploy --app "$app" --image "$image" --region "$region" --env DATABASE_URL="$new_connection_string" $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
+      bash -c "flyctl deploy --app "\""$app"\"" --image "\""$image"\"" --region "\""$region"\"" --env DATABASE_URL="\""$new_connection_string"\"" $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
         value="${secret}"
         echo -n "--env $secret='${!value}' "
       done)"
@@ -75,7 +75,7 @@ if ! flyctl status --app "$app"; then
   fi
 else # If the App already exists, deploy it again and reset secrets
   if [ "$INPUT_UPDATE" != "false" ]; then
-    bash -c "flyctl deploy --app "$app" --image "$image" --region "$region" --strategy bluegreen $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
+    bash -c "flyctl deploy --app "\""$app"\"" --image "\""$image"\"" --region "\""$region"\"" --strategy bluegreen $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
       value="${secret}"
       echo -n "--env $secret='${!value}' "
     done)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,7 +69,7 @@ if [ -n "$INPUT_POSTGRES" ]; then
 fi
 
 if [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy immediate
+  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy bluegreen
 fi
 
 if [ -n "$INPUT_SECRETS" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,7 +70,9 @@ if [ -n "$INPUT_POSTGRES" ]; then
 fi
 
 if [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy immediate
+  connection_string=$(echo $db_output | sed -e 's/[[:space:]]*Connection string:[[:space:]]*//g')
+  new_connection_string=$(echo $connection_string | sed -e "s/\.flycast/.internal/g")
+  flyctl deploy --app "$app" --env DATABASE_URL=$new_connection_string --image "$image" --region "$region" --strategy immediate
 fi
 
 if [ -n "$INPUT_SECRETS" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,10 +65,10 @@ if ! flyctl status --app "$app"; then
       # Fix until Prisma can deal with IPv6 or Fly gives us something else
       connection_string=$(echo $db_output | sed -e 's/[[:space:]]*Connection string:[[:space:]]*//g')
       new_connection_string=$(echo $connection_string | sed -e "s/\.flycast/.internal/g")
-      bash -c "flyctl deploy --app "$app" --image "$image" --region "$region" --env DATABASE_URL=$new_connection_string $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
+      bash -c "flyctl deploy --app "$app" --image "$image" --region "$region" --env DATABASE_URL="$new_connection_string" $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
         value="${secret}"
         echo -n "--env $secret='${!value}' "
-      done) || true"
+      done)"
     fi
   else # If PostgreSQL is not requested, just deploy the application
     flyctl deploy --app "$app" --image "$image" --region "$region"
@@ -78,7 +78,7 @@ else # If the App already exists, deploy it again and reset secrets
     bash -c "flyctl deploy --app "$app" --image "$image" --region "$region" --strategy bluegreen $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
       value="${secret}"
       echo -n "--env $secret='${!value}' "
-    done) || true"
+    done)"
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,7 @@ if ! flyctl status --app "$app"; then
       flyctl postgres attach --app "$app" "$postgres_app" || true
 
       # Fix until Prisma can deal with IPv6 or Fly gives us something else
+      # see https://github.com/prisma/prisma/issues/18079
       connection_string=$(echo $db_output | sed -e 's/[[:space:]]*Connection string:[[:space:]]*//g')
       new_connection_string=$(echo $connection_string | sed -e "s/\.flycast/.internal/g")
       bash -c "flyctl deploy --app "\""$app"\"" --image "\""$image"\"" --region "\""$region"\"" --env DATABASE_URL="\""$new_connection_string"\"" $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,8 +61,9 @@ if [ -n "$INPUT_POSTGRES" ]; then
     fi
 
     # Fix until Prisma can deal with IPv6 or Fly gives us something else
-    connection_string=$(echo $db_output | sed -e 's/\.flycast/.internal/g')
-    flyctl secrets --app $app set DATABASE_URL=$connection_string || true
+    connection_string=$(echo $db_output | sed -e 's/[[:space:]]*Connection string:[[:space:]]*//g')
+    new_connection_string=$(echo $connection_string | sed -e "s/\.flycast/.internal/g")
+    flyctl secrets --app $app set DATABASE_URL=$new_connection_string || true
   fi
 
   flyctl postgres attach --app "$app" "$postgres_app" || true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,9 +61,8 @@ if [ -n "$INPUT_POSTGRES" ]; then
     fi
 
     # Fix until Prisma can deal with IPv6 or Fly gives us something else
-    connection_string=$(echo $db_output | sed -e 's/[[:space:]]*Connection string:[[:space:]]*//g')
-    new_connection_string=$(echo $connection_string | sed -e "s/\[.*\]/${postgres_app}.internal/g")
-    flyctl secrets --app $app set DATABASE_URL=$new_connection_string || true
+    connection_string=$(echo $db_output | sed -e 's/\.flycast/.internal/g')
+    flyctl secrets --app $app set DATABASE_URL=$connection_string || true
   fi
 
   flyctl postgres attach --app "$app" "$postgres_app" || true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,7 @@ fi
 # Create (using launch as create doesn't accept --region) the Fly app.
 if ! flyctl status --app "$app"; then
   flyctl launch --copy-config --name "$app" --org "$org" --image "$image" --region "$region" --no-deploy
+  flyctl scale count 2 --app "$app"
 fi
 
 # Attach postgres cluster to the app if specified.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,15 +69,15 @@ if [ -n "$INPUT_POSTGRES" ]; then
   flyctl postgres attach --app "$app" "$postgres_app" || true
 fi
 
-if [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy bluegreen
-fi
-
 if [ -n "$INPUT_SECRETS" ]; then
   bash -c "flyctl secrets --app $app set $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
     value="${secret}"
     echo -n " $secret='${!value}' "
   done) || true"
+fi
+
+if [ "$INPUT_UPDATE" != "false" ]; then
+  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy bluegreen
 fi
 
 # Make some info available to the GitHub workflow.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,7 +70,7 @@ if [ -n "$INPUT_POSTGRES" ]; then
 fi
 
 if [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy bluegreen
+  flyctl deploy --app "$app" --image "$image" --region "$region" --strategy immediate
 fi
 
 if [ -n "$INPUT_SECRETS" ]; then


### PR DESCRIPTION
This PR bumps the GitHub Action to v3.0 with the following changes:
- we only create the PostgreSQL Cluster if it doesn't already exist yet (given specified in the configuration)
- create PostgreSQL cluster with an initial size of 2 so that the write main instance and the first read replica are in the same region, additional read replicas can still be spawned in additional regions with `postgres_cluster_regions` configuration
- replace Fly's Database URL ending with `.flycast` to `.internal` as a fix for [Prisma Issue](https://github.com/prisma/prisma/issues/18079)
- pass secrets as `--env` option to the `flyctl deploy` command instead of using `flyctl secrets` to avoid first deployment having no secrets

Fixes TRB-494