### PR TITLE
Revert to rolling strategy as bluegreen is not supported by Apps V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
 
       - name: Deploy
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v3.1
+        uses: fewlinesco/fly-io-review-apps@v3.2
 ```
 
 ## Cleaning up GitHub environments
@@ -86,7 +86,7 @@ jobs:
 
       - name: Deploy app
         id: deploy
-        uses: fewlinesco/fly-io-review-apps@v3.1
+        uses: fewlinesco/fly-io-review-apps@v3.2
 
       - name: Clean up GitHub environment
         uses: strumwolf/delete-deployment-environment@v2
@@ -111,7 +111,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v3.1
+    uses: fewlinesco/fly-io-review-apps@v3.2
     with:
       postgres: true
 ```
@@ -125,7 +125,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/fly-io-review-apps@v3.1
+    uses: fewlinesco/fly-io-review-apps@v3.2
     with:
       postgres: true
       region: cdg
@@ -146,7 +146,7 @@ steps:
   - uses: actions/checkout@v3
 
   - name: Deploy redis
-    uses: fewlinesco/fly-io-review-apps@v3.1
+    uses: fewlinesco/fly-io-review-apps@v3.2
     with:
       update: false # Don't need to re-deploy redis when the PR is updated
       path: redis # Keep fly.toml in a subdirectory to avoid confusing flyctl
@@ -155,7 +155,7 @@ steps:
 
   - name: Deploy app
     id: deploy
-    uses: fewlinesco/ffly-io-review-apps@v3.1
+    uses: fewlinesco/ffly-io-review-apps@v3.2
     with:
       name: pr-${{ github.event.number }}-myapp-app
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,10 +102,8 @@ else
 fi
 
 # Make some info available to the GitHub workflow.
-flyctl status --app "$app" --json >status.json
-hostname=$(jq -r .Hostname status.json)
-appid=$(jq -r .ID status.json)
+hostname=$(flyctl status --app "$app" | grep Hostname | sed -e 's/[[:space:]]*Hostname =[[:space:]]*//g')
 
 echo "hostname=$hostname" >> $GITHUB_OUTPUT
 echo "url=https://$hostname" >> $GITHUB_OUTPUT
-echo "id=$appid" >> $GITHUB_OUTPUT
+echo "id=$app" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,7 +87,7 @@ if ! flyctl status --app "$app"; then
 else 
   # If the App already exists, deploy it again with secrets as they may have changed
   if [ "$INPUT_UPDATE" != "false" ]; then
-    bash -c "flyctl deploy --app "\""$app"\"" --image "\""$image"\"" --region "\""$region"\"" --strategy bluegreen $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
+    bash -c "flyctl deploy --app "\""$app"\"" --image "\""$image"\"" --region "\""$region"\"" --strategy rolling $(for secret in $(echo $INPUT_SECRETS | tr ";" "\n") ; do
       value="${secret}"
       echo -n "--env $secret='${!value}' "
     done)"


### PR DESCRIPTION
- use rolling deployment strategy instead of bluegreen as the later is not compatible with Fly Apps v2
- use `flyctl machine clone` instead of `flyctl scale` as the later is not compatible with Fly Apps v2
- fix for `flyctl status --json` no longer outputing JSON